### PR TITLE
Filter header 'HTTP/1.1 200 Connection established' responsed by proxy

### DIFF
--- a/src/Aw/Nusoap/SoapTransportHttp.php
+++ b/src/Aw/Nusoap/SoapTransportHttp.php
@@ -610,7 +610,8 @@ class SoapTransportHttp extends NusoapBase {
 								'HTTP/1.1 302',
 								'HTTP/1.0 401',
 								'HTTP/1.1 401',
-								'HTTP/1.0 200 Connection established');
+								'HTTP/1.0 200 Connection established',
+								'HTTP/1.1 200 Connection established');
 		foreach ($skipHeaders as $hd) {
 			$prefix = substr($data, 0, strlen($hd));
 			if ($prefix == $hd) return true;


### PR DESCRIPTION
According to this issue:[PHP Notice: Undefined index: content-type in asistenteweb/nusoap/src/Aw/Nusoap/NusoapClient.php on line 472](https://github.com/AsistenteWeb/NuSOAP/issues/5)